### PR TITLE
Dynamically pulled login-data

### DIFF
--- a/comcast.py
+++ b/comcast.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 from __future__ import print_function
 
+from html.parser import HTMLParser
 import json
 import logging
 import os
@@ -17,27 +18,19 @@ session = requests.Session()
 username = os.environ['COMCAST_USERNAME']
 password = os.environ['COMCAST_PASSWORD']
 
-logger.debug("Finding req_id for login...")
+logger.debug("Finding form inputs for login...")
 res = session.get('https://customer.xfinity.com/oauth/force_connect/?continue=%23%2Fdevices')
 #res = session.get('https://login.comcast.net/login?r=comcast.net&s=oauth&continue=https%3A%2F%2Flogin.comcast.net%2Foauth%2Fauthorize%3Fclient_id%3Dmy-account-web%26redirect_uri%3Dhttps%253A%252F%252Fcustomer.xfinity.com%252Foauth%252Fcallback%26response_type%3Dcode%26state%3D%2523%252Fdevices%26response%3D1&client_id=my-account-web')
 assert res.status_code == 200
-m = re.search(r'<input type="hidden" name="reqId" value="(.*?)">', res.text)
-req_id = m.group(1)
-logger.debug("Found req_id = %r", req_id)
-
+data = dict(map(
+    lambda x: [x[0], HTMLParser().unescape(x[1])],
+    re.findall(r'<input.*?name="(.*?)".*?value="(.*?)".*?>', res.text)
+))
+logger.debug("Found with the following input fields: {}".format(data))
 data = {
     'user': username,
     'passwd': password,
-    'reqId': req_id,
-    'deviceAuthn': 'false',
-    's': 'oauth',
-    'forceAuthn': '1',
-    'r': 'comcast.net',
-    'ipAddrAuthn': 'false',
-    'continue': 'https://oauth.xfinity.com/oauth/authorize?client_id=my-account-web&prompt=login&redirect_uri=https%3A%2F%2Fcustomer.xfinity.com%2Foauth%2Fcallback&response_type=code&state=%23%2Fdevices&response=1',
-    'passive': 'false',
-    'client_id': 'my-account-web',
-    'lang': 'en',
+    **data
 }
 
 logger.debug("Posting to login...")


### PR DESCRIPTION
This replaces the hard-coded (except for req-id) dictionary, with a dynamically created one, based on the input fields on the web page. It extends the same logic for pulling the req-id to all the other, currently, hard-coded key-values.